### PR TITLE
Have ExceptionResponse pass body up as exception message

### DIFF
--- a/zoot-core/src/main/scala/net/fwbrasil/zoot/core/response/Response.scala
+++ b/zoot-core/src/main/scala/net/fwbrasil/zoot/core/response/Response.scala
@@ -7,5 +7,5 @@ case class Response[T](body: T = "",
 case class ExceptionResponse(body: String = "",
                              status: ResponseStatus = ResponseStatus.INTERNAL_SERVER_ERROR,
                              headers: Map[String, String] = Map())
-    extends Exception
+    extends Exception(body)
     


### PR DESCRIPTION
@fwbrasil this is the cause of not being able to see what is wrong with my requests to Zoot server. Currently renders like this without the error message:

```
SEVERE: A server service  threw an exception
net.fwbrasil.zoot.core.response.ExceptionResponse
    at net.fwbrasil.zoot.core.endpoint.RequestConsumer$$anonfun$verifyMissingParams$3.apply(RequestConsumer.scala:45)
    at net.fwbrasil.zoot.core.endpoint.RequestConsumer$$anonfun$verifyMissingParams$3.apply(RequestConsumer.scala:44)
    at net.fwbrasil.zoot.core.util.RichIterable$RichIterable.ifNonEmpty(RichIterable.scala:26)
    at net.fwbrasil.zoot.core.endpoint.RequestConsumer.verifyMissingParams(RequestConsumer.scala:44)
    at net.fwbrasil.zoot.core.endpoint.RequestConsumer.net$fwbrasil$zoot$core$endpoint$RequestConsumer$$values(RequestConsumer.scala:38)
    at net.fwbrasil.zoot.core.endpoint.RequestConsumer$$anonfun$consumeRequest$1.apply(RequestConsumer.scala:26)
    at net.fwbrasil.zoot.core.endpoint.RequestConsumer$$anonfun$consumeRequest$1.apply(RequestConsumer.scala:25)
    at scala.Option.map(Option.scala:145)
    at net.fwbrasil.zoot.core.endpoint.RequestConsumer.consumeRequest(RequestConsumer.scala:25)
    at net.fwbrasil.zoot.core.Server$$anonfun$apply$1.apply(Server.scala:31)
    at net.fwbrasil.zoot.core.Server$$anonfun$apply$1.apply(Server.scala:30)
    at net.fwbrasil.zoot.core.util.RichIterable$RichIterable$$anonfun$findDefined$1$$anonfun$apply$1.apply(RichIterable.scala:9)
    at net.fwbrasil.zoot.core.util.RichIterable$RichIterable$$anonfun$findDefined$1$$anonfun$apply$1.apply(RichIterable.scala:9)
    at scala.Option.orElse(Option.scala:257)
    at net.fwbrasil.zoot.core.util.RichIterable$RichIterable$$anonfun$findDefined$1.apply(RichIterable.scala:9)
    at net.fwbrasil.zoot.core.util.RichIterable$RichIterable$$anonfun$findDefined$1.apply(RichIterable.scala:8)
    at scala.collection.LinearSeqOptimized$class.foldLeft(LinearSeqOptimized.scala:111)
    at scala.collection.immutable.List.foldLeft(List.scala:84)
    at net.fwbrasil.zoot.core.util.RichIterable$RichIterable.findDefined(RichIterable.scala:7)
    at net.fwbrasil.zoot.core.Server.apply(Server.scala:30)
    at net.fwbrasil.zoot.core.Server.apply(Server.scala:18)
    at net.fwbrasil.zoot.finagle.FinagleServer$$anon$1$$anonfun$apply$1.apply(FinagleServer.scala:27)
    at net.fwbrasil.zoot.finagle.FinagleServer$$anon$1$$anonfun$apply$1.apply(FinagleServer.scala:26)
    at scala.concurrent.Future$$anonfun$flatMap$1.apply(Future.scala:251)
    at scala.concurrent.Future$$anonfun$flatMap$1.apply(Future.scala:249)
    at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
    at scala.concurrent.impl.ExecutionContextImpl$$anon$3.exec(ExecutionContextImpl.scala:107)
    at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
    at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
    at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
    at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```
